### PR TITLE
Feature: randomize daily scraper execution time to distribute load

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,12 @@ Poté zkontrolujte zdali se v **HA** vytvořily statické entity.
 Aplikace reaguje na `eventy` kterými se stahují data. Pokud si chcete stáhnout data tak jsou k dispozici následující možnosti.
 
 > [!TIP]
-> Data pro aktuální měsíc a předchozí den se stahují každý den v náhodném čase mezi `10:15` a `14:15` (distribuce zátěže na EDC portál).
+> Data pro aktuální měsíc a předchozí den se stahují každý den v náhodném čase, ve výchozím nastavení mezi `10:15` a `11:00` (distribuce zátěže na EDC portál).
+> Čas spuštění a velikost náhodné odchylky lze nastavit v Home Assistantu (Settings > Devices&Services > Entities):
+> - `input_datetime.edc_daily_run_time` (EDC Daily Run Base Time) - Čas spuštění (výchozí: 10:15)
+> - `input_number.edc_daily_run_randomization` (EDC Randomization Window) - Velikost náhodné odchylky v minutách (výchozí: 45)
+>
+> Změny času spuštění nebo velikosti náhodné odchylky se projeví okamžitě bez nutnosti restartu AppDaemona.
 
 ### Stažení aktuálních dat
 Pro stažení aktuálních dat lze spustit entitu/skript "EDC Import daily data" (Settings > Devices & Services > Entities)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Poté zkontrolujte zdali se v **HA** vytvořily statické entity.
 Aplikace reaguje na `eventy` kterými se stahují data. Pokud si chcete stáhnout data tak jsou k dispozici následující možnosti.
 
 > [!TIP]
-> Data pro aktuální měsíc a předchozí den se stahují každý den v `10:15`.
+> Data pro aktuální měsíc a předchozí den se stahují každý den v náhodném čase mezi `10:15` a `14:15` (distribuce zátěže na EDC portál).
 
 ### Stažení aktuálních dat 
 Pro stažení aktuálních date b HA pošlete event `edc_import_daily` bez parametrů. Stáhne se aktuální a předcjhozí měsíc.

--- a/packages/edc_importer.yaml
+++ b/packages/edc_importer.yaml
@@ -3,6 +3,26 @@ template:
       - name: "EDC Running"
         unique_id: edc_running
         state: "off"
+
+input_datetime:
+  edc_daily_run_time:
+    name: EDC Daily Run Base Time
+    icon: mdi:clock-outline
+    has_date: false
+    has_time: true
+    initial: "10:15"
+
+input_number:
+  edc_daily_run_randomization:
+    name: EDC Randomization Window
+    icon: mdi:shuffle-variant
+    min: 0
+    max: 120
+    step: 5
+    initial: 45
+    unit_of_measurement: "min"
+    mode: slider
+
 input_text:
   edc_script_duration:
     name: EDC Script Duration
@@ -94,3 +114,7 @@ homeassistant:
       friendly_name: EDC Producer EANs
     edc_consumer_eans:
       friendly_name: EDC Consumer EANs
+    input_datetime.edc_daily_run_time:
+      friendly_name: EDC Daily Run Base Time
+    input_number.edc_daily_run_randomization:
+      friendly_name: EDC Randomization Window


### PR DESCRIPTION
Randomize daily scraper execution across a 4-hour window (10:15-14:15) to prevent multiple instances of Home Assistant from hitting the EDC portal simultaneously at the same time.